### PR TITLE
fix: update "Getting Started" link in _index.html

### DIFF
--- a/hugo/content/_index.html
+++ b/hugo/content/_index.html
@@ -21,7 +21,7 @@ type: sprotty
             Fully customizable · Server and client-side diagramming · Easy integration · Powerful timesaver
         </p>
         <div class="flex flex-row gap-10 justify-center items-center pb-10">
-            <a href="./docs/getting-started" class="bg-sprottyMidBlue bg-opacity-50 rounded-xl px-8 py-3 text-sprottyDarkBlue shadow-md">Get started</a>
+            <a href="./docs/learn/getting-started" class="bg-sprottyMidBlue bg-opacity-50 rounded-xl px-8 py-3 text-sprottyDarkBlue shadow-md">Get started</a>
             <a href="#what-is-sprotty" class="text-sprottyDarkBlue">
             <div class="flex flex-row gap-2">
                     <p>Learn more</p>


### PR DESCRIPTION
Currently, from website https://sprotty.org/ the "[Get started](https://sprotty.org/docs/getting-started)" link return a 404 pages :

"Lost?
Error 404
Seems like what you are looking for can't be found. Don't worry, we can bring you back to the [homepage](https://sprotty.org/docs/)."

the changes fix with the good link